### PR TITLE
feat: Add before_template_load action hook for hypermedia templates

### DIFF
--- a/src/Render.php
+++ b/src/Render.php
@@ -131,6 +131,9 @@ class Render
 
         // For backward compatibility
         $hxvals = $hmvals;
+        
+        // Run actions before loading the template
+        do_action('hmapi/before_template_load', $template_name, $hmvals);
 
         // Load the template
         require_once $template_path;


### PR DESCRIPTION
Hi @EstebanForge minor thing that I think would improve DX, or at least I would find it useful!

## Problem
When working with multiple hypermedia templates, I often need to perform common setup tasks (like data preparation, validation, or logging) before each template loads. Currently, this might require duplicating code across multiple template files, this would help avoid that.

## Solution
Added a `do_action('hmapi/before_template_load', $template_name, $hmvals)` hook that fires before each hypermedia template is loaded. This provides a centralized point for common template preparation logic.

## Usage Example
```php
// In functions.php or a plugin
add_action('hmapi/before_template_load', function($template_name, $hmvals) {
    // Log template access
    error_log("Loading hypermedia template: {$template_name}");
    // Make some variables available
    $var = some_data();
}, 10, 2);
```

## Technical Details
- Hook fires before `require_once $template_path`
- Passes `$template_name` and `$hmvals` as parameters
- Follows WordPress action hook conventions
- Minimal performance impact

This is basically a developer quality-of-life improvement.